### PR TITLE
relax the poison version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule Recaptcha.Mixfile do
   defp deps do
     [
       {:httpoison, "~> 0.8.3"},
-      {:poison, ">= 1.5.0"}
+      {:poison, ">= 1.5.0 and < 2.0.0"}
     ]
   end
 


### PR DESCRIPTION
Relaxing the version of poison (which only introduces breaking changes post 2.x as far as I can tell) allows users not to be tied so strictly to what is now quite an old version of the library. (now at 2.1.0)
